### PR TITLE
Accept statement page

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,6 +36,7 @@ export class MyApp {
     { title: 'Home', component: 'HomePage' },
     { title: 'Benefit Finder', component: 'BenefitFinderPage' },
     { title: 'EI Reporting', component: 'EiReportingPage' },
+    { title: 'Acceptance Statement', component: 'AcceptanceStatementPage' },
     { title: 'Search', component: 'JobSearchPage' },
     { title: 'Life Events', component: 'LifeEventsPage' },
     { title: 'My Notifications', component: 'MynotificationsPage' },

--- a/src/pages/acceptance-statement/acceptance-statement.html
+++ b/src/pages/acceptance-statement/acceptance-statement.html
@@ -12,7 +12,7 @@
         <ion-icon class="menu" name='menu'></ion-icon>
       </button>
   
-      <ion-title class="page-title">EI Reporting
+      <ion-title class="page-title">{{this.report.schedule}}
       </ion-title>
   
       <ion-buttons end>
@@ -25,5 +25,10 @@
 
 
 <ion-content padding>
+
+  <div class="statement-section">
+    <h1 class="statement-header"></h1>
+    <p class="statement-content"></p>
+  </div>
 
 </ion-content>

--- a/src/pages/acceptance-statement/acceptance-statement.html
+++ b/src/pages/acceptance-statement/acceptance-statement.html
@@ -1,0 +1,29 @@
+<!--
+  Generated template for the AcceptanceStatementPage page.
+
+  See http://ionicframework.com/docs/components/#navigation for more info on
+  Ionic pages and navigation.
+-->
+<ion-header>
+
+    <ion-navbar>
+  
+      <button ion-button menuToggle icon-only>
+        <ion-icon class="menu" name='menu'></ion-icon>
+      </button>
+  
+      <ion-title class="page-title">EI Reporting
+      </ion-title>
+  
+      <ion-buttons end>
+        <ion-icon class="help" name="help-circle"></ion-icon>
+      </ion-buttons>
+  
+    </ion-navbar>
+  
+  </ion-header>
+
+
+<ion-content padding>
+
+</ion-content>

--- a/src/pages/acceptance-statement/acceptance-statement.module.ts
+++ b/src/pages/acceptance-statement/acceptance-statement.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { AcceptanceStatementPage } from './acceptance-statement';
+
+@NgModule({
+  declarations: [
+    AcceptanceStatementPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(AcceptanceStatementPage),
+  ],
+})
+export class AcceptanceStatementPageModule {}

--- a/src/pages/acceptance-statement/acceptance-statement.scss
+++ b/src/pages/acceptance-statement/acceptance-statement.scss
@@ -1,0 +1,49 @@
+page-acceptance-statement {
+  // Nav Bar CSS Starts Here
+  .menu {
+    color: #fff;
+  }
+  .start {
+    position: absolute;
+    left: 0;
+  }
+  .toolbar-background {
+    background-color: #31485b;
+  }
+  .toolbar-title-md {
+    padding: 0 6px;
+    margin-top: 0px;
+    font-weight: 600;
+  }
+  .toolbar-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    min-height: 100%;
+    font-size: 1.7rem;
+  }
+  .page-title {
+    text-align: center;
+    color: white;
+  }
+  .back-button {
+    color: #fff;
+  }
+  .back {
+    //padding-left: 5rem;
+    margin-left: 5rem;
+    color: #fff;
+    font-size: 20px;
+    width: 14.5px;
+    margin-right: 10rem;
+    left: 0;
+  }
+  .help {
+    //padding-right: 3rem;
+    margin-right: 3rem;
+    color: #fff;
+    font-size: 22.5px;
+  }
+  // Nav Bar CSS ends here
+}

--- a/src/pages/acceptance-statement/acceptance-statement.ts
+++ b/src/pages/acceptance-statement/acceptance-statement.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
+import { Report } from '../../models/mockEiReport';
 
 /**
  * Generated class for the AcceptanceStatementPage page.
@@ -15,7 +17,11 @@ import { IonicPage, NavController, NavParams } from 'ionic-angular';
 })
 export class AcceptanceStatementPage {
 
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
+  report: Report;
+
+  constructor(public translate: TranslateService,
+    public navParams: NavParams) {
+    this.report = navParams.get('report');
   }
 
   ionViewDidLoad() {

--- a/src/pages/acceptance-statement/acceptance-statement.ts
+++ b/src/pages/acceptance-statement/acceptance-statement.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavController, NavParams } from 'ionic-angular';
+
+/**
+ * Generated class for the AcceptanceStatementPage page.
+ *
+ * See https://ionicframework.com/docs/components/#navigation for more info on
+ * Ionic pages and navigation.
+ */
+
+@IonicPage()
+@Component({
+  selector: 'page-acceptance-statement',
+  templateUrl: 'acceptance-statement.html',
+})
+export class AcceptanceStatementPage {
+
+  constructor(public navCtrl: NavController, public navParams: NavParams) {
+  }
+
+  ionViewDidLoad() {
+    console.log('ionViewDidLoad AcceptanceStatementPage');
+  }
+
+}

--- a/src/pages/ei-reporting/ei-reporting.ts
+++ b/src/pages/ei-reporting/ei-reporting.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
 import { Reports } from '../../mocks/providers/mock-ei-reports';
 import { Report } from '../../models/mockEiReport';
+import { SitePages } from '..';
 
 /**
  * Generated class for the EiReportingPage page.
@@ -28,5 +29,5 @@ export class EiReportingPage {
     console.log('ionViewDidLoad EiReportingPage');
   }
 
-  startReport = (report) => this.navCtrl.push('QuestionairePage', {report});
+  startReport = (report) => this.navCtrl.push(SitePages.AcceptanceStatement, {report});
 }

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,6 +2,7 @@ import { IssueWithReportPage } from './issue-with-report/issue-with-report';
 import { BenefitFinderPage } from './benefit-finder/benefit-finder';
 
 export enum SitePages {
+  AcceptanceStatement = 'AcceptanceStatementPage',
   BenefitFinder = 'BenefitFinderPage',
   Confirmation = 'ConfirmationPage',
   EILogin = 'LoginPage',

--- a/src/pages/questionaire/questionaire.ts
+++ b/src/pages/questionaire/questionaire.ts
@@ -17,16 +17,8 @@ import { Report } from '../../models/mockEiReport';
 })
 export class QuestionairePage {
 
-    report: Report;
-
-  constructor( public translate: TranslateService,
-               public navParams: NavParams ) {
-    this.report = navParams.get('report');
-  }
-
   ionViewDidLoad() {
     console.log('ionViewDidLoad QuestionairePage');
-    console.log(this.report);
   }
 
 }


### PR DESCRIPTION
- Page is now navigated to when user chooses to start a new report
- Takes selected report schedule and uses as page title, as per design
- Changed navigation to use Calvin's newly added globals