### PR TITLE
Fixed tests in HomePage.spec.ts

### DIFF
--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -1,3 +1,4 @@
+import { HomePageCarouselComponent } from './../../components/home-page-carousel/home-page-carousel';
 import { EiReportingPage } from './../ei-reporting/ei-reporting';
 import { CommonTestModule } from "./../../app/sharedModules";
 import { HomePage } from "./home";
@@ -23,7 +24,7 @@ describe("The Home Page", () => {
   function setupTestBedConfig(){
     fakeNavController = new NavMock();
     TestBed.configureTestingModule({
-      declarations: CommonTestModule.getDeclarations([HomePage]),
+      declarations: CommonTestModule.getDeclarations([HomePage, HomePageCarouselComponent]),
       imports: CommonTestModule.getImports(),
       providers: CommonTestModule.getProviders([
         { provide: NavController, useValue: fakeNavController }


### PR DESCRIPTION
Added HomePageCarouselComponent to HomePage.spec.ts to fix the breaking tests. The HomePage tests didn't properly load this component in the test.