### PR TITLE
Language selection in settings complete

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,7 +28,7 @@ import { Lang, User, LangCodes } from "../providers";
       </ion-list>
 
       <ion-list class="nav-menu-list">
-        <button menuClose ion-item *ngFor="let p of userOptions; let last = last" color="navMenuButton"
+        <button menuClose ion-item *ngFor="let p of userSelections; let last = last" color="navMenuButton"
         [class.last-item]="last"
         (click)="openSettings(p)">
           {{p.title}}
@@ -88,7 +88,9 @@ export class MyApp {
     }
   ];
 
-  userOptions: any[] = [{ title: "Settings", component: SitePages.Settings }];
+  userSelections: any[] = [
+    { title: "Settings", component: SitePages.Settings }
+  ];
 
   pagesInProgress: any[] = [
     { title: "Blank Page", component: SitePages.BlankPage },

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -22,13 +22,19 @@
       </button>
     </ion-list>
 
-    <ion-list *ngIf="page == 'language'">
-      <button ion-item>
-        {{ 'LANGUAGE_BUTTON_FRENCH' | translate }}
-      </button>
-      <button ion-item>
-        {{ 'LANGUAGE_BUTTON_ENGLISH' | translate }}
-      </button>
+    <ion-list radio-group *ngIf="page == 'language'">
+      <ion-item>
+        <ion-label>
+          {{ 'LANGUAGE_BUTTON_FRENCH' | translate }}
+        </ion-label>
+        <ion-radio (ionSelect)='changeLang("fr")'></ion-radio>
+      </ion-item>
+      <ion-item>
+        <ion-label>
+          {{ 'LANGUAGE_BUTTON_ENGLISH' | translate }}
+        </ion-label>
+        <ion-radio (ionSelect)='changeLang("en")'></ion-radio>
+      </ion-item>
     </ion-list>
 
     <ion-list *ngIf="page == 'notifications'">

--- a/src/pages/settings/settings.ts
+++ b/src/pages/settings/settings.ts
@@ -2,7 +2,7 @@ import { Component } from "@angular/core";
 import { FormBuilder, FormGroup } from "@angular/forms";
 import { TranslateService } from "@ngx-translate/core";
 import { IonicPage, NavController, NavParams } from "ionic-angular";
-
+import { User } from "../../providers/user/user";
 import { Settings } from "../../providers";
 
 /**
@@ -44,7 +44,8 @@ export class SettingsPage {
     public settings: Settings,
     public formBuilder: FormBuilder,
     public navParams: NavParams,
-    public translate: TranslateService
+    public translate: TranslateService,
+    public user: User
   ) {}
 
   _buildForm() {
@@ -69,6 +70,16 @@ export class SettingsPage {
     this.form.valueChanges.subscribe(v => {
       this.settings.merge(this.form.value);
     });
+  }
+
+  changeLang(selection) {
+    console.log(selection);
+    console.log(this.user.Lang);
+    if (selection === this.user.Lang) {
+      console.log("Selected Language is already active!");
+    } else {
+      this.user.alternateLang();
+    }
   }
 
   ionViewDidLoad() {


### PR DESCRIPTION
- Users may now select preferred language under settings
- If user selects already active language, no action occurs
- If new language is selected, app refreshes and user is returned to settings